### PR TITLE
Adding documentation links to the examples in comments

### DIFF
--- a/examples/simple/helloworld.js
+++ b/examples/simple/helloworld.js
@@ -12,7 +12,7 @@ export class HelloWorld extends LitElement {
       controlName: 'Hello World',
       fallbackDisableSubmit: false,
       version: '1.2',
-      properties: {
+      properties: { //A custom configuration field. See https://help.nintex.com/en-US/formplugins/Reference/CustomField.htm
         who: {
           type: 'string',
           title: 'Who',

--- a/examples/simple/iframe.js
+++ b/examples/simple/iframe.js
@@ -2,7 +2,7 @@ import {css, html, LitElement, styleMap} from 'https://cdn.jsdelivr.net/gh/lit/d
 
 export class SampleIframe extends LitElement {
     // Define scoped styles right with your component, in plain CSS
-    static styles = css`
+    static styles = css`  //Add custom CSS. See https://help.nintex.com/en-US/formplugins/Reference/Style.htm
       :host {
         height: 100%;
         width: 100%;
@@ -27,7 +27,7 @@ export class SampleIframe extends LitElement {
             iconUrl: "one-line-text",
             groupName: 'Visual',
             version: '1.3',
-            properties: {
+            properties: { //Custom configuration fields. See https://help.nintex.com/en-US/formplugins/Reference/CustomField.htm
                 src: {
                     type: 'string',
                     title: 'Source URL',
@@ -40,7 +40,7 @@ export class SampleIframe extends LitElement {
                 }
             },
             standardProperties: {
-                readOnly: true,
+                readOnly: true,  //Add a read-only mode. See https://help.nintex.com/en-US/formplugins/Reference/ReadOnly.htm
                 required: true,
                 description: true,
             }

--- a/src/components/animated-logo/animated-logo.ts
+++ b/src/components/animated-logo/animated-logo.ts
@@ -6,7 +6,7 @@ import { PluginContract } from '@nintex/form-plugin-contract';
 
 @customElement('nintex-sample-animated-logo')
 export class NintexSampleAnimatedLogo extends LitElement {
-  static styles = styles;
+  static styles = styles;  //Add custom CSS. See https://help.nintex.com/en-US/formplugins/Reference/Style.htm
 
   defaultLogo = 'Logo';
   @property({ type: String }) word = this.defaultLogo;

--- a/src/components/chart-pie/chart-pie.config.ts
+++ b/src/components/chart-pie/chart-pie.config.ts
@@ -10,7 +10,7 @@ export const config: PluginContract = {
     description: false,
     fieldLabel: true,
   },
-  properties: {
+  properties: { //Custom configuration fields. See https://help.nintex.com/en-US/formplugins/Reference/CustomField.htm
     bindings: {
       type: 'string',
       enum: ['chart1', 'chart2', 'chart3'],

--- a/src/components/grid-js/grid-js.config.ts
+++ b/src/components/grid-js/grid-js.config.ts
@@ -5,7 +5,7 @@ export const config: PluginContract = {
   groupName: 'Visual',
   fallbackDisableSubmit: false,
   version: '1.0',
-  properties: {
+  properties: { //Custom configuration fields. See https://help.nintex.com/en-US/formplugins/Reference/CustomField.htm
     sortable: {
       type: 'boolean',
       title: 'Allow Sorting',

--- a/src/components/grid-js/grid-js.ts
+++ b/src/components/grid-js/grid-js.ts
@@ -9,7 +9,7 @@ import { styles } from './grid-js.styles';
  */
 @customElement('nintex-sample-grid-js')
 export class NintexSampleGirdJs extends LitElement {
-  static styles = styles;
+  static styles = styles; //Add custom CSS. See https://help.nintex.com/en-US/formplugins/Reference/Style.htm
   /**
    * Allow Grid Sorting
    */

--- a/src/components/iframe/iframe.ts
+++ b/src/components/iframe/iframe.ts
@@ -8,7 +8,7 @@ import { styles } from './iframe.styles';
 @customElement('nintex-sample-iframe')
 export class NintexSampleIframe extends LitElement {
   // Define scoped styles right with your component, in plain CSS
-  static styles = styles;
+  static styles = styles; //Add custom CSS. See https://help.nintex.com/en-US/formplugins/Reference/Style.htm
 
   @property()
   name!: string;
@@ -28,7 +28,7 @@ export class NintexSampleIframe extends LitElement {
       iconUrl: 'one-line-text',
       groupName: 'Visual',
       version: '1.3',
-      properties: {
+      properties: { //Custom configuration fields. See https://help.nintex.com/en-US/formplugins/Reference/CustomField.htm
         src: {
           type: 'string',
           title: 'Source URL',
@@ -49,7 +49,7 @@ export class NintexSampleIframe extends LitElement {
         },
       },
       standardProperties: {
-        readOnly: true,
+        readOnly: true, //Add a read-only mode. See https://help.nintex.com/en-US/formplugins/Reference/ReadOnly.htm
         required: true,
         description: true,
       },

--- a/src/components/material-slider/material-slider.config.ts
+++ b/src/components/material-slider/material-slider.config.ts
@@ -7,11 +7,11 @@ export const config: PluginContract = {
   description: 'Material Slider',
   groupName: 'Material',
   standardProperties: {
-    readOnly: true,
+    readOnly: true,  //Add a read-only mode. See https://help.nintex.com/en-US/formplugins/Reference/ReadOnly.htm
     required: true,
     description: false,
   },
-  properties: {
+  properties: { //Custom configuration fields. See https://help.nintex.com/en-US/formplugins/Reference/CustomField.htm
     titleField: {
       type: 'string',
       title: 'Title',
@@ -28,7 +28,7 @@ export const config: PluginContract = {
       type: 'number',
       title: 'Max',
     },
-    value: {
+    value: {  //A field to pass a value to the workflow as a variable. See https://help.nintex.com/en-US/formplugins/Reference/StoreValue.htm
       type: 'number',
       isValueField: true,
     },

--- a/src/components/material-slider/material-slider.ts
+++ b/src/components/material-slider/material-slider.ts
@@ -7,7 +7,7 @@ import { updatePluginValue } from '../../utils/events';
 
 @customElement('nintex-sample-slider')
 export class NintexSampleSlider extends LitElement {
-  static styles = css`
+  static styles = css` //Add custom CSS. See https://help.nintex.com/en-US/formplugins/Reference/Style.htm
     :host {
       /* height: 100%; */
       width: 100%;
@@ -21,7 +21,7 @@ export class NintexSampleSlider extends LitElement {
   titleField!: string;
 
   @property({ type: Boolean })
-  disabled = false;
+  disabled = false;  //Add a read-only mode. See https://help.nintex.com/en-US/formplugins/Reference/ReadOnly.htm
 
   @property({ type: Number })
   min = 0;
@@ -30,7 +30,7 @@ export class NintexSampleSlider extends LitElement {
   max = 100;
 
   @property({ type: Number, reflect: true })
-  value = 0;
+  value = 0;  //A field to pass a value to the workflow as a variable. See https://help.nintex.com/en-US/formplugins/Reference/StoreValue.htm
 
   public static getMetaConfig(): Promise<PluginContract> {
     return import('./material-slider.config').then(x => x.config);

--- a/src/components/material-textfield/material-textfield.ts
+++ b/src/components/material-textfield/material-textfield.ts
@@ -30,7 +30,7 @@ const fire = <T>(
 
 @customElement('nintex-sample-textfield')
 export class NintexSampleTextfield extends LitElement {
-  static styles = styles;
+  static styles = styles;  //Add custom CSS. See https://help.nintex.com/en-US/formplugins/Reference/Style.htm
 
   @property()
   label!: string;
@@ -39,7 +39,7 @@ export class NintexSampleTextfield extends LitElement {
   @property({ type: Boolean })
   outlined: boolean = false;
   @property({ type: Boolean })
-  readOnly: boolean = false;
+  readOnly: boolean = false;   //Add a read-only mode. See https://help.nintex.com/en-US/formplugins/Reference/ReadOnly.htm
 
   static getMetaConfig(): Promise<PluginContract> | PluginContract {
     // plugin contract information
@@ -48,12 +48,12 @@ export class NintexSampleTextfield extends LitElement {
       fallbackDisableSubmit: false,
       iconUrl: 'one-line-text',
       version: '1',
-      properties: {
+      properties: { //A custom configuration field. See https://help.nintex.com/en-US/formplugins/Reference/CustomField.htm
         outlined: {
           type: 'boolean',
           title: 'Show Outline',
         },
-        value: {
+        value: {  //A field to pass a value to the workflow as a variable. See https://help.nintex.com/en-US/formplugins/Reference/StoreValue.htm
           type: 'string',
           title: 'Value',
           // this is to mark the field as value field. it should only be defined once in the list of properties
@@ -65,7 +65,7 @@ export class NintexSampleTextfield extends LitElement {
         fieldLabel: true,
         description: true,
         defaultValue: true,
-        readOnly: true,
+        readOnly: true,   //Add a read-only mode. See https://help.nintex.com/en-US/formplugins/Reference/ReadOnly.htm
       },
     };
   }

--- a/src/components/styled-input/styled-input.ts
+++ b/src/components/styled-input/styled-input.ts
@@ -4,8 +4,8 @@ import { PluginContract } from '@nintex/form-plugin-contract';
 
 @customElement('nintex-styled-input')
 export class NintexStyledInput extends LitElement {
-  // Define scoped styles right with your component, in plain CSS
-  static styles = css`
+  // Define scoped styles right with your component, in plain CSS.  See https://help.nintex.com/en-US/formplugins/Reference/Style.htm
+  static styles = css` 
     .form-control {
       color: var(--ntx-form-theme-color-secondary);
       background-color: var(
@@ -26,7 +26,7 @@ export class NintexStyledInput extends LitElement {
   @property()
   value: string = 'hello';
   @property({ type: Boolean })
-  readOnly: boolean = false;
+  readOnly: boolean = false;  //Add a read-only mode. See https://help.nintex.com/en-US/formplugins/Reference/ReadOnly.htm
 
   static getMetaConfig(): Promise<PluginContract> | PluginContract {
     // plugin contract information
@@ -35,11 +35,12 @@ export class NintexStyledInput extends LitElement {
       fallbackDisableSubmit: false,
       iconUrl: 'one-line-text',
       version: '1',
-      properties: {
-        value: {
+      properties: { //A custom configuration field. See https://help.nintex.com/en-US/formplugins/Reference/CustomField.htm
+        value: { //A custom field to store the value. 
           type: 'string',
           title: 'Value',
-          // this is to mark the field as value field. it should only be defined once in the list of properties
+          /* This marks the field as the value field. Should only be defined once in the list of properties. 
+             See https://help.nintex.com/en-US/formplugins/Reference/StoreValue.htm */
           isValueField: true,
           defaultValue: 'This is a text field default value',
         },
@@ -47,7 +48,7 @@ export class NintexStyledInput extends LitElement {
       standardProperties: {
         fieldLabel: true,
         defaultValue: true,
-        readOnly: true,
+        readOnly: true,  //Add a read-only mode. See https://help.nintex.com/en-US/formplugins/Reference/ReadOnly.htm
       },
     };
   }


### PR DESCRIPTION
Added links to the SDK documentation for common tasks like custom css, read-only, storing a value and creating custom config fields.